### PR TITLE
[3주차] 예약 API 구현, Lock 적용 & 동시성 이슈 fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,3 +201,12 @@ explain select
 - gradle 의존성 최적화
 - infrastructure 모듈에서 cache, mysql 등 모듈 분리
 - 검색 쿼리 최적화
+
+## 3주차 시나리오
+> 3주차는 동시성 이슈 해결에 초점을 맞췄습니다. 단계별로 Lock 을 적용하고, Redisson 라이브러리에 Lua script 가 작성된 것을 확인합니다. 또한 성능 최적화를 위해 AOP 분산락에서 함수형 분산락을 적용하는 경험을 합니다. 
+
+- [X] 예약 API 구현
+- [X] Pessimistic Lock 구현
+- [X] Optimistic Lock 구현
+- [ ] AOP 기반 Distributed Lock 구현
+- [ ] 함수형 기반 Distributed Lock 구현

--- a/api/src/main/kotlin/com/hanghe/redis/dto/MovieReservationRequest.kt
+++ b/api/src/main/kotlin/com/hanghe/redis/dto/MovieReservationRequest.kt
@@ -1,0 +1,12 @@
+package com.hanghe.redis.dto
+
+data class MovieReservationRequest(
+    val screeningId: Long,
+    val userId: String,
+    val seatIds: List<Long>
+) {
+    init {
+        require(seatIds.isNotEmpty()) { "좌석을 1개 이상 선택해야 합니다." }
+        require(seatIds.size <= 5) { "최대 5개의 좌석만 예매할 수 있습니다." }
+    }
+}

--- a/api/src/main/kotlin/com/hanghe/redis/reservation/ReservationControllerV1.kt
+++ b/api/src/main/kotlin/com/hanghe/redis/reservation/ReservationControllerV1.kt
@@ -22,4 +22,15 @@ class ReservationControllerV1(
             seatIds = request.seatIds,
         )
     }
+
+    @PostMapping("/pessimistic")
+    fun reservationWithPessimisticLock(
+        @RequestBody request: MovieReservationRequest
+    ) {
+        service.reservationWithPessimisticLock(
+            screeningId = request.screeningId,
+            userId = request.userId,
+            seatIds = request.seatIds,
+        )
+    }
 }

--- a/api/src/main/kotlin/com/hanghe/redis/reservation/ReservationControllerV1.kt
+++ b/api/src/main/kotlin/com/hanghe/redis/reservation/ReservationControllerV1.kt
@@ -1,0 +1,25 @@
+package com.hanghe.redis.reservation
+
+import com.hanghe.redis.dto.MovieReservationRequest
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/api/v1/movies/reservations")
+class ReservationControllerV1(
+    private val service: MovieReservationService
+) {
+
+    @PostMapping
+    fun reservation(
+        @RequestBody request: MovieReservationRequest
+    ) {
+        service.reservation(
+            screeningId = request.screeningId,
+            userId = request.userId,
+            seatIds = request.seatIds,
+        )
+    }
+}

--- a/api/src/main/kotlin/com/hanghe/redis/reservation/ReservationControllerV1.kt
+++ b/api/src/main/kotlin/com/hanghe/redis/reservation/ReservationControllerV1.kt
@@ -33,4 +33,15 @@ class ReservationControllerV1(
             seatIds = request.seatIds,
         )
     }
+
+    @PostMapping("/optimistic")
+    fun reservationWithOptimisticLock(
+        @RequestBody request: MovieReservationRequest
+    ) {
+        service.reservationWithOptimisticLock(
+            screeningId = request.screeningId,
+            userId = request.userId,
+            seatIds = request.seatIds,
+        )
+    }
 }

--- a/application/build.gradle.kts
+++ b/application/build.gradle.kts
@@ -9,4 +9,6 @@ dependencies {
     testImplementation("io.kotest:kotest-assertions-core:5.3.2")
     testImplementation("io.kotest:kotest-framework-api:5.3.2")
     testImplementation("io.mockk:mockk:1.13.5")
+
+    testImplementation("net.bytebuddy:byte-buddy:1.14.7")
 }

--- a/application/src/main/kotlin/com/hanghe/redis/reservation/MovieReservationService.kt
+++ b/application/src/main/kotlin/com/hanghe/redis/reservation/MovieReservationService.kt
@@ -1,0 +1,61 @@
+package com.hanghe.redis.reservation
+
+import com.hanghe.redis.message.MessageClient
+import com.hanghe.redis.movie.seat.SeatCodes
+import com.hanghe.redis.mysql.reservation.ReservationRepository
+import com.hanghe.redis.mysql.screening.ScreeningRepository
+import com.hanghe.redis.mysql.seat.SeatRepository
+import com.hanghe.redis.screening.ScreeningEntity
+import jakarta.persistence.EntityNotFoundException
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+@Transactional
+class MovieReservationService(
+    val reservationRepository: ReservationRepository,
+    val seatRepository: SeatRepository,
+    val screeningRepository: ScreeningRepository,
+    val messageClient: MessageClient,
+
+    private val reservationPolicy: UserReservationPolicy
+) {
+
+    fun reservation(
+        screeningId: Long,
+        userId: String,
+        seatIds: List<Long>
+    ) {
+        val reservations = reservationRepository.findByScreeningId(screeningId)
+
+        reservationPolicy.validate(
+            userId = userId,
+            existingCount = reservations.count { it.createdBy == userId },
+            newCount = seatIds.size
+        )
+
+        val seats = seatRepository.findByScreeningIdAndSeatIds(screeningId, seatIds)
+        val requestSeatCodes = SeatCodes(seats)
+        val reservedSeatCodes = reservations
+            .takeIf { it.isNotEmpty() }
+            ?.let { SeatCodes(it.map { r -> r.seat.seatCode }) }
+
+        requestSeatCodes.validate(reservedSeatCodes)
+
+        val screening: ScreeningEntity = screeningRepository.findById(screeningId)
+            ?: throw EntityNotFoundException()
+
+        val newReservations = seats.map { seat ->
+            ReservationEntity(
+                screening = screening,
+                seat = seat,
+            ).apply {
+                this.createdBy = userId
+            }
+        }
+        reservationRepository.saveAll(newReservations)
+
+        // TODO: 비동기 적용
+        messageClient.send(userId, screening.theaterName, screening.movie.title, requestSeatCodes)
+    }
+}

--- a/application/src/main/kotlin/com/hanghe/redis/reservation/MovieReservationService.kt
+++ b/application/src/main/kotlin/com/hanghe/redis/reservation/MovieReservationService.kt
@@ -58,4 +58,38 @@ class MovieReservationService(
         // TODO: 비동기 적용
         messageClient.send(userId, screening.theaterName, screening.movie.title, requestSeatCodes)
     }
+
+    fun reservationWithPessimisticLock(screeningId: Long, userId: String, seatIds: List<Long>) {
+        val reservations = reservationRepository.findByScreeningId(screeningId)
+
+        reservationPolicy.validate(
+            userId = userId,
+            existingCount = reservations.count { it.createdBy == userId },
+            newCount = seatIds.size
+        )
+
+        val seats = seatRepository.findByTheaterIdAndSeatIdsByPessimisticLock(screeningId, seatIds)
+        val requestSeatCodes = SeatCodes(seats)
+        val reservedSeatCodes = reservations
+            .takeIf { it.isNotEmpty() }
+            ?.let { SeatCodes(it.map { r -> r.seat.seatCode }) }
+
+        requestSeatCodes.validate(reservedSeatCodes)
+
+        val screening: ScreeningEntity = screeningRepository.findById(screeningId)
+            ?: throw EntityNotFoundException()
+
+        val newReservations = seats.map { seat ->
+            ReservationEntity(
+                screening = screening,
+                seat = seat,
+            ).apply {
+                this.createdBy = userId
+            }
+        }
+        reservationRepository.saveAll(newReservations)
+
+        // TODO: 비동기 적용
+        messageClient.send(userId, screening.theaterName, screening.movie.title, requestSeatCodes)
+    }
 }

--- a/application/src/main/kotlin/com/hanghe/redis/reservation/MovieReservationService.kt
+++ b/application/src/main/kotlin/com/hanghe/redis/reservation/MovieReservationService.kt
@@ -2,14 +2,23 @@ package com.hanghe.redis.reservation
 
 import com.hanghe.redis.message.MessageClient
 import com.hanghe.redis.movie.seat.SeatCodes
+import com.hanghe.redis.movie.seat.SeatEntity
 import com.hanghe.redis.mysql.reservation.ReservationRepository
 import com.hanghe.redis.mysql.screening.ScreeningRepository
 import com.hanghe.redis.mysql.seat.SeatRepository
 import com.hanghe.redis.screening.ScreeningEntity
-import jakarta.persistence.EntityNotFoundException
+import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
+/**
+ * 예약에 대한 비즈니스 로직
+ *
+ * 1. 상영 시간에 예약된 정보를 조회하고, 최대 예매 좌석에 대한 유효성 검증을 진행한다.
+ * 2. 예약 요청한 좌석 정보를 조회하고, 좌석의 형식, 중복 예약 등에 대한 유효성 검증을 진행한다.
+ * 3. 예매에 대한 동시성 이슈를 해결하고자 Pessimistic, Optimistic, Distributed Lock 을 적용하여 예매를 진행한다.
+ * 4. 예매 정보에 대한 메시지를 발송한다.
+ */
 @Service
 @Transactional
 class MovieReservationService(
@@ -21,109 +30,112 @@ class MovieReservationService(
     private val reservationPolicy: UserReservationPolicy
 ) {
 
+    private val logger = LoggerFactory.getLogger(MovieReservationService::class.java)
+
     fun reservation(
         screeningId: Long,
         userId: String,
         seatIds: List<Long>
     ) {
         val reservations = reservationRepository.findByScreeningId(screeningId)
-
-        reservationPolicy.validate(
-            userId = userId,
-            existingCount = reservations.count { it.createdBy == userId },
-            newCount = seatIds.size
-        )
+        reservationPolicy.validate(userId, reservations.countByUser(userId), seatIds.size)
 
         val seats = seatRepository.findByScreeningIdAndSeatIds(screeningId, seatIds)
         val requestSeatCodes = SeatCodes(seats)
-        val reservedSeatCodes = reservations
-            .takeIf { it.isNotEmpty() }
-            ?.let { SeatCodes(it.map { r -> r.seat.seatCode }) }
+        val reservedSeatCodes = SeatCodes(reservations)
 
         requestSeatCodes.validate(reservedSeatCodes)
 
-        val screening: ScreeningEntity = screeningRepository.findById(screeningId)
-            ?: throw EntityNotFoundException()
+        val existingReservedSeatIds = reservationRepository
+            .findByScreeningIdAndSeatIds(screeningId, seatIds)
+            .mapNotNull { it.seat.id }
 
-        val newReservations = seats.map { seat ->
-            ReservationEntity(
-                screening = screening,
-                seat = seat,
-            ).apply {
-                this.createdBy = userId
-            }
+        if (existingReservedSeatIds.isNotEmpty()) {
+            throw IllegalStateException("요청하신 좌석 중 이미 예약된 좌석이 존재합니다.")
         }
+
+        val screening = screeningRepository.getById(screeningId)
+        val newReservations = reservationEntities(seats, screening, userId)
         reservationRepository.saveAll(newReservations)
 
         // TODO: 비동기 적용
         messageClient.send(userId, screening.theaterName, screening.movie.title, requestSeatCodes)
     }
+
 
     fun reservationWithPessimisticLock(screeningId: Long, userId: String, seatIds: List<Long>) {
         val reservations = reservationRepository.findByScreeningId(screeningId)
+        reservationPolicy.validate(userId, reservations.countByUser(userId), seatIds.size)
 
-        reservationPolicy.validate(
-            userId = userId,
-            existingCount = reservations.count { it.createdBy == userId },
-            newCount = seatIds.size
-        )
-
-        val seats = seatRepository.findByTheaterIdAndSeatIdsByPessimisticLock(screeningId, seatIds)
+        val seats = seatRepository.findByTheaterIdAndSeatIds(screeningId, seatIds)
         val requestSeatCodes = SeatCodes(seats)
-        val reservedSeatCodes = reservations
-            .takeIf { it.isNotEmpty() }
-            ?.let { SeatCodes(it.map { r -> r.seat.seatCode }) }
+        val reservedSeatCodes = SeatCodes(reservations)
 
         requestSeatCodes.validate(reservedSeatCodes)
+        validateConcurrencyReservationWithPessimisticLock(screeningId, seatIds)
 
-        val screening: ScreeningEntity = screeningRepository.findById(screeningId)
-            ?: throw EntityNotFoundException()
-
-        val newReservations = seats.map { seat ->
-            ReservationEntity(
-                screening = screening,
-                seat = seat,
-            ).apply {
-                this.createdBy = userId
-            }
-        }
+        val screening = screeningRepository.getById(screeningId)
+        val newReservations = reservationEntities(seats, screening, userId)
         reservationRepository.saveAll(newReservations)
 
         // TODO: 비동기 적용
         messageClient.send(userId, screening.theaterName, screening.movie.title, requestSeatCodes)
     }
 
+
     fun reservationWithOptimisticLock(screeningId: Long, userId: String, seatIds: List<Long>) {
         val reservations = reservationRepository.findByScreeningId(screeningId)
+        reservationPolicy.validate(userId, reservations.countByUser(userId), seatIds.size)
 
-        reservationPolicy.validate(
-            userId = userId,
-            existingCount = reservations.count { it.createdBy == userId },
-            newCount = seatIds.size
-        )
-
-        val seats = seatRepository.findByTheaterIdAndSeatIdsByOptimisticLock(screeningId, seatIds)
+        val seats = seatRepository.findByTheaterIdAndSeatIds(screeningId, seatIds)
         val requestSeatCodes = SeatCodes(seats)
-        val reservedSeatCodes = reservations
-            .takeIf { it.isNotEmpty() }
-            ?.let { SeatCodes(it.map { r -> r.seat.seatCode }) }
+        val reservedSeatCodes = SeatCodes(reservations)
 
         requestSeatCodes.validate(reservedSeatCodes)
+        validateConcurrencyReservationWithOptimisticLock(screeningId, seatIds)
 
-        val screening: ScreeningEntity = screeningRepository.findById(screeningId)
-            ?: throw EntityNotFoundException()
-
-        val newReservations = seats.map { seat ->
-            ReservationEntity(
-                screening = screening,
-                seat = seat,
-            ).apply {
-                this.createdBy = userId
-            }
-        }
+        val screening = screeningRepository.getById(screeningId)
+        val newReservations = reservationEntities(seats, screening, userId)
         reservationRepository.saveAll(newReservations)
 
         // TODO: 비동기 적용
         messageClient.send(userId, screening.theaterName, screening.movie.title, requestSeatCodes)
+    }
+
+    private fun reservationEntities(
+        seats: List<SeatEntity>,
+        screening: ScreeningEntity,
+        userId: String
+    ) = seats.map { seat ->
+        ReservationEntity(
+            screening = screening,
+            seat = seat,
+        ).apply {
+            this.createdBy = userId
+        }
+    }
+
+    private fun validateConcurrencyReservationWithPessimisticLock(screeningId: Long, seatIds: List<Long>) {
+        val existingReservedSeatIds = reservationRepository
+            .findByScreeningIdAndSeatIdsWithPessimisticLock(screeningId, seatIds)
+            .map { it.seat.id }
+
+        // TODO: Custom Exception
+        if (existingReservedSeatIds.isNotEmpty()) {
+            logger.error("Movie Reservation ConcurrentModificationException! SeatIds: ${existingReservedSeatIds.joinToString()}")
+            throw ConcurrentModificationException("요청하신 좌석 중 이미 예약된 좌석이 존재합니다.")
+        }
+    }
+
+    private fun validateConcurrencyReservationWithOptimisticLock(screeningId: Long, seatIds: List<Long>) {
+        val existingReservedSeatIds = reservationRepository
+            .findByScreeningIdAndSeatIdsWithOptimisticLock(screeningId, seatIds)
+            .map { it.seat.id }
+
+        // TODO: Custom Exception
+        if (existingReservedSeatIds.isNotEmpty()) {
+            logger.error("Movie Reservation ConcurrentModificationException! SeatIds: ${existingReservedSeatIds.joinToString()}")
+            throw ConcurrentModificationException("요청하신 좌석 중 이미 예약된 좌석이 존재합니다.")
+        }
     }
 }

--- a/application/src/main/kotlin/com/hanghe/redis/reservation/UserReservationPolicy.kt
+++ b/application/src/main/kotlin/com/hanghe/redis/reservation/UserReservationPolicy.kt
@@ -20,3 +20,5 @@ class UserReservationPolicy(
         }
     }
 }
+
+fun List<ReservationEntity>.countByUser(userId: String) = this.count { it.createdBy == userId }

--- a/application/src/main/kotlin/com/hanghe/redis/reservation/UserReservationPolicy.kt
+++ b/application/src/main/kotlin/com/hanghe/redis/reservation/UserReservationPolicy.kt
@@ -1,0 +1,22 @@
+package com.hanghe.redis.reservation
+
+import org.springframework.stereotype.Component
+
+@Component
+class UserReservationPolicy(
+    private val maxAllowedSeatsPerScreening: Int = 5
+) {
+
+    fun validate(
+        userId: String,
+        existingCount: Int,
+        newCount: Int
+    ) {
+        require(existingCount + newCount <= maxAllowedSeatsPerScreening) {
+            """
+            상영 별 최대 $maxAllowedSeatsPerScreening 개의 좌석을 예매할 수 있습니다.
+            사용자: $userId, 이미 예매한 좌석 수: $existingCount, 요청한 좌석 수: $newCount
+            """.trimIndent()
+        }
+    }
+}

--- a/application/src/test/kotlin/reservation/MovieReservationConcurrencyTest.kt
+++ b/application/src/test/kotlin/reservation/MovieReservationConcurrencyTest.kt
@@ -1,0 +1,79 @@
+package reservation
+
+import com.hanghe.redis.message.MessageClient
+import com.hanghe.redis.movie.seat.SeatCode
+import com.hanghe.redis.movie.seat.SeatEntity
+import com.hanghe.redis.mysql.reservation.ReservationRepository
+import com.hanghe.redis.mysql.screening.ScreeningRepository
+import com.hanghe.redis.mysql.seat.SeatRepository
+import com.hanghe.redis.reservation.MovieReservationService
+import com.hanghe.redis.reservation.UserReservationPolicy
+import com.hanghe.redis.theater.TheaterEntity
+import fixture.ScreeningEntityFixture
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.Runs
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
+import java.util.concurrent.atomic.AtomicInteger
+
+class MovieReservationConcurrencyTest : BehaviorSpec({
+
+    val reservationRepository = mockk<ReservationRepository>(relaxUnitFun = true)
+    val seatRepository = mockk<SeatRepository>()
+    val screeningRepository = mockk<ScreeningRepository>()
+    val messageClient = mockk<MessageClient>(relaxed = true)
+    val reservationPolicy = mockk<UserReservationPolicy>()
+
+    val service = MovieReservationService(
+        reservationRepository,
+        seatRepository,
+        screeningRepository,
+        messageClient,
+        reservationPolicy
+    )
+
+    val screeningId = 1L
+    val seatIds = listOf(1L)
+    val userId1 = "userA"
+    val userId2 = "userB"
+
+    val theater = TheaterEntity(name = "CGV")
+    val seat = SeatEntity(1L, SeatCode("A1"), theater)
+    val screening = ScreeningEntityFixture.create()
+
+    given("MovieReservationService.reservation() 동시성 테스트") {
+        `when`("락이 없는 상태에서 두 사용자가 동시에 예매를 시도하면") {
+            then("예외가 발생하지 않고 중복 예매에 성공한다") {
+                every { reservationRepository.findByScreeningId(screeningId) } returns emptyList()
+                every { seatRepository.findByScreeningIdAndSeatIds(screeningId, seatIds) } returns listOf(seat)
+                every { screeningRepository.findById(screeningId) } returns screening
+                every { reservationPolicy.validate(any(), any(), any()) } just Runs
+                every { reservationRepository.saveAll(any()) } returnsArgument 0
+
+                val executor = Executors.newFixedThreadPool(2)
+                val latch = CountDownLatch(2)
+                val exceptionCount = AtomicInteger()
+
+                listOf(userId1, userId2).forEach { userId ->
+                    executor.submit {
+                        try {
+                            service.reservation(screeningId, userId, seatIds)
+                        } catch (e: Throwable) {
+                            exceptionCount.incrementAndGet()
+                        } finally {
+                            latch.countDown()
+                        }
+                    }
+                }
+
+                latch.await()
+
+                exceptionCount.get() shouldBe 0
+            }
+        }
+    }
+})

--- a/domain/src/main/kotlin/com/hanghe/redis/movie/seat/SeatCode.kt
+++ b/domain/src/main/kotlin/com/hanghe/redis/movie/seat/SeatCode.kt
@@ -1,0 +1,26 @@
+package com.hanghe.redis.movie.seat
+
+@JvmInline
+value class SeatCode(val value: String) {
+    private val row: Char get() = value[0]
+    val column: Int get() = value.substring(1).toInt()
+
+    init {
+        require(value.matches(Regex("^[A-E][1-5]\$"))) {
+            "좌석 코드는 A1~E5 형식이어야 합니다: $value"
+        }
+    }
+
+    fun validateNextTo(next: SeatCode) {
+        // TODO: Custom Exception
+        require(this.row == next.row) { "좌석은 동일한 행에 있어야 합니다. (${this.value}, ${next.value})" }
+
+        require(this.column + 1 == next.column) { "좌석은 같은 행에서 연속된 열이어야 합니다. (${this.column} → ${next.column})" }
+    }
+
+    companion object {
+        operator fun invoke(value: String): SeatCode = from(value)
+
+        private fun from(raw: String): SeatCode = SeatCode(raw.trim().uppercase())
+    }
+}

--- a/domain/src/main/kotlin/com/hanghe/redis/movie/seat/SeatCodes.kt
+++ b/domain/src/main/kotlin/com/hanghe/redis/movie/seat/SeatCodes.kt
@@ -1,0 +1,42 @@
+package com.hanghe.redis.movie.seat
+
+@JvmInline
+value class SeatCodes(val values: List<SeatCode>) {
+
+    init {
+        require(values.isNotEmpty()) { "좌석이 비어있습니다." }
+    }
+
+    fun validate(seatCodes: SeatCodes?) {
+        validateContinuity()
+//        validateNoOverlapWith(seatCodes)
+    }
+
+    // 모든 좌석이 이어 붙어진 형식인지 검증
+    fun validateContinuity() {
+        values
+            .sortedBy { it.column }
+            .zipWithNext { prev, next -> prev.validateNextTo(next) }
+    }
+
+    // 중복 예약이 존재하지 않는지 검증
+    fun validateNoOverlapWith(existing: SeatCodes?) {
+        if (existing == null) return
+
+        val duplicated = values.filter { it in existing.values }
+
+        require(duplicated.isEmpty()) {
+            "요청하신 예약 중 이미 예약된 좌석이 존재합니다. 중복 좌석: ${duplicated.map { it.value }}"
+        }
+    }
+
+    companion object {
+        private fun from(seats: List<SeatEntity>): SeatCodes = SeatCodes(seats.map { it.seatCode })
+
+        operator fun invoke(seats: List<SeatEntity>): SeatCodes = from(seats)
+    }
+}
+
+fun SeatCodes.toLogString(): String {
+    return this.values.joinToString(", ") { it.value }
+}

--- a/domain/src/main/kotlin/com/hanghe/redis/movie/seat/SeatCodes.kt
+++ b/domain/src/main/kotlin/com/hanghe/redis/movie/seat/SeatCodes.kt
@@ -1,5 +1,7 @@
 package com.hanghe.redis.movie.seat
 
+import com.hanghe.redis.reservation.ReservationEntity
+
 @JvmInline
 value class SeatCodes(val values: List<SeatCode>) {
 
@@ -25,15 +27,23 @@ value class SeatCodes(val values: List<SeatCode>) {
 
         val duplicated = values.filter { it in existing.values }
 
+        // TODO: Custom Exception
         require(duplicated.isEmpty()) {
-            "요청하신 예약 중 이미 예약된 좌석이 존재합니다. 중복 좌석: ${duplicated.map { it.value }}"
+            "요청하신 좌석 중 이미 예약된 좌석이 존재합니다. 중복 좌석: ${duplicated.map { it.value }}"
         }
     }
 
     companion object {
         private fun from(seats: List<SeatEntity>): SeatCodes = SeatCodes(seats.map { it.seatCode })
 
+        private fun from(reservations: List<ReservationEntity>): SeatCodes? {
+            return reservations
+                .takeIf { it.isNotEmpty() }
+                ?.let { SeatCodes(it.map { r -> r.seat.seatCode }) }
+        }
+
         operator fun invoke(seats: List<SeatEntity>): SeatCodes = from(seats)
+        operator fun invoke(reservations: List<ReservationEntity>): SeatCodes? = from(reservations)
     }
 }
 

--- a/domain/src/main/kotlin/com/hanghe/redis/movie/seat/SeatCodes.kt
+++ b/domain/src/main/kotlin/com/hanghe/redis/movie/seat/SeatCodes.kt
@@ -9,7 +9,7 @@ value class SeatCodes(val values: List<SeatCode>) {
 
     fun validate(seatCodes: SeatCodes?) {
         validateContinuity()
-//        validateNoOverlapWith(seatCodes)
+        validateNoOverlapWith(seatCodes)
     }
 
     // 모든 좌석이 이어 붙어진 형식인지 검증

--- a/domain/src/main/kotlin/com/hanghe/redis/movie/seat/SeatEntity.kt
+++ b/domain/src/main/kotlin/com/hanghe/redis/movie/seat/SeatEntity.kt
@@ -19,7 +19,7 @@ class SeatEntity(
     val id: Long? = null,
 
     @Column(nullable = false)
-    val seatCode: String,
+    val seatCode: SeatCode,
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "theater_id", nullable = false)

--- a/domain/src/test/kotlin/com/hanghe/redis/movie/seat/SeatCodeTest.kt
+++ b/domain/src/test/kotlin/com/hanghe/redis/movie/seat/SeatCodeTest.kt
@@ -1,0 +1,95 @@
+package com.hanghe.redis.movie.seat
+
+import io.kotest.assertions.throwables.shouldNotThrow
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+
+class SeatCodeTest : BehaviorSpec({
+
+    given("SeatCode.invoke()") {
+        `when`("올바른 좌석 코드인 경우") {
+            then("SeatCode 객체가 정상적으로 생성된다") {
+                val expected = "A1"
+
+                val actual = SeatCode(expected)
+
+                actual.value shouldBe expected
+            }
+        }
+
+        `when`("좌석 코드가 A1 ~ E5 가 아닌 경우") {
+            then("예외가 발생한다") {
+                val invalidCodes = listOf("4A", "F1", "AA", "B0", "", "Z9")
+
+                invalidCodes.forEach {
+                    shouldThrow<IllegalArgumentException> {
+                        SeatCode(it)
+                    }.message shouldContain "좌석 코드는 A1~E5 형식이어야 합니다"
+                }
+            }
+        }
+    }
+
+    given("SeatCode.validateNextTo()") {
+
+        `when`("두 좌석이 같은 행에 있고 열이 연속될 때") {
+            then("검증을 통과한다") {
+                val a1 = SeatCode("A1")
+                val a2 = SeatCode("A2")
+
+                shouldNotThrow<IllegalArgumentException> {
+                    a1.validateNextTo(a2)
+                }
+            }
+        }
+
+        `when`("두 좌석이 다른 행일 때") {
+            then("예외가 발생한다") {
+                val a1 = SeatCode("A1")
+                val b2 = SeatCode("B2")
+
+                shouldThrow<IllegalArgumentException> {
+                    a1.validateNextTo(b2)
+                }.message shouldContain "동일한 행에 있어야 합니다"
+            }
+        }
+
+        `when`("두 좌석의 열이 연속되지 않을 때") {
+            then("예외가 발생한다") {
+                val a1 = SeatCode("A1")
+                val a3 = SeatCode("A3")
+
+                shouldThrow<IllegalArgumentException> {
+                    a1.validateNextTo(a3)
+                }.message shouldContain "연속된 열이어야 합니다"
+            }
+        }
+    }
+
+    given("SeatCodes.toLogString()") {
+
+        `when`("좌석 코드가 여러 개 주어졌을 때") {
+            then("콤마로 연결된 문자열을 반환한다") {
+                val seatCodes = SeatCodes(listOf("A1", "A2", "A3").map { SeatCode(it) })
+
+                val result = seatCodes.toLogString()
+
+                result shouldBe "A1, A2, A3"
+            }
+        }
+
+        `when`("좌석 코드가 한 개만 주어졌을 때") {
+            then("해당 좌석 코드 문자열만 반환한다") {
+                val seatCodes = SeatCodes(listOf(SeatCode("B1")))
+
+                val result = seatCodes.toLogString()
+
+                result shouldBe "B1"
+            }
+        }
+    }
+
+})
+

--- a/domain/src/test/kotlin/com/hanghe/redis/movie/seat/SeatCodesTest.kt
+++ b/domain/src/test/kotlin/com/hanghe/redis/movie/seat/SeatCodesTest.kt
@@ -1,0 +1,75 @@
+package com.hanghe.redis.movie.seat
+
+import io.kotest.assertions.throwables.shouldNotThrow
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.string.shouldContain
+
+class SeatCodesTest : BehaviorSpec({
+
+    given("SeatCodes.validateContinuity()") {
+
+        `when`("좌석들이 같은 행에서 연속된 열을 가질 때") {
+            then("검증을 통과한다") {
+                val codes = listOf("A2", "A1", "A3").map { SeatCode(it) }
+                val seatCodes = SeatCodes(codes)
+
+                shouldNotThrow<IllegalArgumentException> {
+                    seatCodes.validateContinuity()
+                }
+            }
+        }
+
+        `when`("좌석들이 연속되지 않은 열을 가질 때") {
+            then("예외가 발생한다") {
+                val invalidSeatCodes = listOf("A1", "A3", "A4").map { SeatCode(it) }
+
+                val actual = SeatCodes(invalidSeatCodes)
+
+                shouldThrow<IllegalArgumentException> {
+                    actual.validateContinuity()
+                }.message shouldContain "연속된 열이어야 합니다"
+            }
+        }
+
+        `when`("좌석들이 다른 행에 있을 때") {
+            then("예외가 발생한다") {
+                val invalidSeatCodes = listOf("A1", "B2").map { SeatCode(it) }
+
+                val actual = SeatCodes(invalidSeatCodes)
+
+                shouldThrow<IllegalArgumentException> {
+                    actual.validateContinuity()
+                }.message shouldContain "동일한 행에 있어야 합니다"
+            }
+        }
+    }
+
+    given("SeatCodes.validateNoOverlapWith()") {
+
+        `when`("중복된 좌석이 없는 경우") {
+            then("검증을 통과한다") {
+                val requested = SeatCodes(listOf("A1", "A2", "A3").map { SeatCode(it) })
+                val existing = SeatCodes(listOf("B1", "B2").map { SeatCode(it) })
+
+                shouldNotThrow<IllegalArgumentException> {
+                    requested.validateNoOverlapWith(existing)
+                }
+            }
+        }
+
+        `when`("중복된 좌석이 존재하는 경우") {
+            then("예외가 발생한다") {
+                val requested = SeatCodes(listOf("A1", "A2", "A3").map { SeatCode(it) })
+                val existing = SeatCodes(listOf("A2", "B2").map { SeatCode(it) })
+
+                val exception = shouldThrow<IllegalArgumentException> {
+                    requested.validateNoOverlapWith(existing)
+                }
+
+                exception.message shouldContain "중복 좌석"
+                exception.message shouldContain "A2"
+            }
+        }
+    }
+})

--- a/http/reservation.http
+++ b/http/reservation.http
@@ -1,0 +1,9 @@
+### 영화 예약 API
+POST http://localhost:8080/api/v1/movies/reservations
+Content-Type: application/json
+
+{
+  "screeningId": 1,
+  "userId": "user-A",
+  "seatIds": [1, 2, 3]
+}

--- a/infrastructure/src/main/kotlin/com/hanghe/redis/message/MessageClient.kt
+++ b/infrastructure/src/main/kotlin/com/hanghe/redis/message/MessageClient.kt
@@ -1,0 +1,8 @@
+package com.hanghe.redis.message
+
+import com.hanghe.redis.movie.seat.SeatCodes
+
+interface MessageClient {
+
+    fun send(userId: String, theaterName: String, title: String, seatCodes: SeatCodes)
+}

--- a/infrastructure/src/main/kotlin/com/hanghe/redis/message/fcm/FCMMessageClient.kt
+++ b/infrastructure/src/main/kotlin/com/hanghe/redis/message/fcm/FCMMessageClient.kt
@@ -1,0 +1,17 @@
+package com.hanghe.redis.message.fcm
+
+import com.hanghe.redis.message.MessageClient
+import com.hanghe.redis.movie.seat.SeatCodes
+import com.hanghe.redis.movie.seat.toLogString
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Component
+
+@Component
+class FCMMessageClient: MessageClient {
+
+    private val logger = LoggerFactory.getLogger(FCMMessageClient::class.java)
+
+    override fun send(userId: String, theaterName: String, title: String, seatCodes: SeatCodes) {
+        logger.info("`$userId`님, $theaterName 영화관의 $title 영화 예매가 완료되었습니다. 좌석 정보는 [${seatCodes.toLogString()}] 입니다.")
+    }
+}

--- a/infrastructure/src/main/kotlin/com/hanghe/redis/mysql/reservation/ReservationJpaRepository.kt
+++ b/infrastructure/src/main/kotlin/com/hanghe/redis/mysql/reservation/ReservationJpaRepository.kt
@@ -1,9 +1,33 @@
 package com.hanghe.redis.mysql.reservation
 
 import com.hanghe.redis.reservation.ReservationEntity
+import jakarta.persistence.LockModeType
+import jakarta.persistence.QueryHint
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Lock
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.jpa.repository.QueryHints
 
 interface ReservationJpaRepository : JpaRepository<ReservationEntity, Long> {
 
     fun findByScreeningId(screeningId: Long): List<ReservationEntity>
+
+    fun findByScreeningIdAndSeatIdIn(screeningId: Long, seatIds: List<Long>): List<ReservationEntity>
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("""
+        SELECT r FROM reservations r
+        WHERE r.screening.id = :screeningId
+            AND r.seat.id IN :seatIds
+    """)
+    @QueryHints(QueryHint(name = "jakarta.persistence.lock.timeout", value = "3000"))
+    fun findByScreeningIdAndSeatIdsWithPessimisticLock(screeningId: Long, seatIds: List<Long>): List<ReservationEntity>
+
+    @Lock(LockModeType.OPTIMISTIC)
+    @Query("""
+        SELECT r FROM reservations r
+        WHERE r.screening.id = :screeningId
+            AND r.seat.id IN :seatIds
+    """)
+    fun findByScreeningIdAndSeatIdsWithOptimisticLock(screeningId: Long, seatIds: List<Long>): List<ReservationEntity>
 }

--- a/infrastructure/src/main/kotlin/com/hanghe/redis/mysql/reservation/ReservationJpaRepository.kt
+++ b/infrastructure/src/main/kotlin/com/hanghe/redis/mysql/reservation/ReservationJpaRepository.kt
@@ -1,0 +1,9 @@
+package com.hanghe.redis.mysql.reservation
+
+import com.hanghe.redis.reservation.ReservationEntity
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface ReservationJpaRepository : JpaRepository<ReservationEntity, Long> {
+
+    fun findByScreeningId(screeningId: Long): List<ReservationEntity>
+}

--- a/infrastructure/src/main/kotlin/com/hanghe/redis/mysql/reservation/ReservationRepository.kt
+++ b/infrastructure/src/main/kotlin/com/hanghe/redis/mysql/reservation/ReservationRepository.kt
@@ -1,0 +1,10 @@
+package com.hanghe.redis.mysql.reservation
+
+import com.hanghe.redis.reservation.ReservationEntity
+
+interface ReservationRepository {
+
+    fun findByScreeningId(screeningId: Long): List<ReservationEntity>
+
+    fun saveAll(newReservations: List<ReservationEntity>)
+}

--- a/infrastructure/src/main/kotlin/com/hanghe/redis/mysql/reservation/ReservationRepository.kt
+++ b/infrastructure/src/main/kotlin/com/hanghe/redis/mysql/reservation/ReservationRepository.kt
@@ -7,4 +7,10 @@ interface ReservationRepository {
     fun findByScreeningId(screeningId: Long): List<ReservationEntity>
 
     fun saveAll(newReservations: List<ReservationEntity>)
+
+    fun findByScreeningIdAndSeatIds(screeningId: Long, seatIds: List<Long>): List<ReservationEntity>
+
+    fun findByScreeningIdAndSeatIdsWithPessimisticLock(screeningId: Long, seatIds: List<Long>): List<ReservationEntity>
+
+    fun findByScreeningIdAndSeatIdsWithOptimisticLock(screeningId: Long, seatIds: List<Long>): List<ReservationEntity>
 }

--- a/infrastructure/src/main/kotlin/com/hanghe/redis/mysql/reservation/ReservationRepositoryImpl.kt
+++ b/infrastructure/src/main/kotlin/com/hanghe/redis/mysql/reservation/ReservationRepositoryImpl.kt
@@ -1,0 +1,18 @@
+package com.hanghe.redis.mysql.reservation
+
+import com.hanghe.redis.reservation.ReservationEntity
+import org.springframework.stereotype.Repository
+
+@Repository
+class ReservationRepositoryImpl(
+    private val repository: ReservationJpaRepository
+) : ReservationRepository {
+
+    override fun findByScreeningId(screeningId: Long): List<ReservationEntity> {
+        return repository.findByScreeningId(screeningId)
+    }
+
+    override fun saveAll(newReservations: List<ReservationEntity>) {
+        repository.saveAll(newReservations)
+    }
+}

--- a/infrastructure/src/main/kotlin/com/hanghe/redis/mysql/reservation/ReservationRepositoryImpl.kt
+++ b/infrastructure/src/main/kotlin/com/hanghe/redis/mysql/reservation/ReservationRepositoryImpl.kt
@@ -5,7 +5,7 @@ import org.springframework.stereotype.Repository
 
 @Repository
 class ReservationRepositoryImpl(
-    private val repository: ReservationJpaRepository
+    private val repository: ReservationJpaRepository,
 ) : ReservationRepository {
 
     override fun findByScreeningId(screeningId: Long): List<ReservationEntity> {
@@ -14,5 +14,20 @@ class ReservationRepositoryImpl(
 
     override fun saveAll(newReservations: List<ReservationEntity>) {
         repository.saveAll(newReservations)
+    }
+
+    override fun findByScreeningIdAndSeatIds(screeningId: Long, seatIds: List<Long>): List<ReservationEntity> {
+        return repository.findByScreeningIdAndSeatIdIn(screeningId, seatIds)
+    }
+
+    override fun findByScreeningIdAndSeatIdsWithPessimisticLock(screeningId: Long, seatIds: List<Long>): List<ReservationEntity> {
+        return repository.findByScreeningIdAndSeatIdsWithPessimisticLock(screeningId, seatIds)
+    }
+
+    override fun findByScreeningIdAndSeatIdsWithOptimisticLock(
+        screeningId: Long,
+        seatIds: List<Long>
+    ): List<ReservationEntity> {
+        return repository.findByScreeningIdAndSeatIdsWithOptimisticLock(screeningId, seatIds)
     }
 }

--- a/infrastructure/src/main/kotlin/com/hanghe/redis/mysql/screening/ScreeningRepository.kt
+++ b/infrastructure/src/main/kotlin/com/hanghe/redis/mysql/screening/ScreeningRepository.kt
@@ -7,4 +7,6 @@ interface ScreeningRepository {
     fun findByMovieIdOrderByStartTime(movieId: Long): List<ScreeningEntity>
 
     fun saveAll(movies: List<ScreeningEntity>): List<ScreeningEntity>
+
+    fun findById(screeningId: Long): ScreeningEntity?
 }

--- a/infrastructure/src/main/kotlin/com/hanghe/redis/mysql/screening/ScreeningRepository.kt
+++ b/infrastructure/src/main/kotlin/com/hanghe/redis/mysql/screening/ScreeningRepository.kt
@@ -9,4 +9,6 @@ interface ScreeningRepository {
     fun saveAll(movies: List<ScreeningEntity>): List<ScreeningEntity>
 
     fun findById(screeningId: Long): ScreeningEntity?
+
+    fun getById(screeningId: Long): ScreeningEntity
 }

--- a/infrastructure/src/main/kotlin/com/hanghe/redis/mysql/screening/ScreeningRepositoryImpl.kt
+++ b/infrastructure/src/main/kotlin/com/hanghe/redis/mysql/screening/ScreeningRepositoryImpl.kt
@@ -1,6 +1,7 @@
 package com.hanghe.redis.mysql.screening
 
 import com.hanghe.redis.screening.ScreeningEntity
+import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Repository
 
 @Repository
@@ -14,5 +15,9 @@ class ScreeningRepositoryImpl(
 
     override fun saveAll(movies: List<ScreeningEntity>): List<ScreeningEntity> {
         return screeningJpaRepository.saveAll(movies)
+    }
+
+    override fun findById(screeningId: Long): ScreeningEntity? {
+        return screeningJpaRepository.findByIdOrNull(screeningId)
     }
 }

--- a/infrastructure/src/main/kotlin/com/hanghe/redis/mysql/screening/ScreeningRepositoryImpl.kt
+++ b/infrastructure/src/main/kotlin/com/hanghe/redis/mysql/screening/ScreeningRepositoryImpl.kt
@@ -1,6 +1,7 @@
 package com.hanghe.redis.mysql.screening
 
 import com.hanghe.redis.screening.ScreeningEntity
+import jakarta.persistence.EntityNotFoundException
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Repository
 
@@ -19,5 +20,9 @@ class ScreeningRepositoryImpl(
 
     override fun findById(screeningId: Long): ScreeningEntity? {
         return screeningJpaRepository.findByIdOrNull(screeningId)
+    }
+
+    override fun getById(screeningId: Long): ScreeningEntity {
+        return findById(screeningId) ?: throw EntityNotFoundException()
     }
 }

--- a/infrastructure/src/main/kotlin/com/hanghe/redis/mysql/seat/SeatJpaRepository.kt
+++ b/infrastructure/src/main/kotlin/com/hanghe/redis/mysql/seat/SeatJpaRepository.kt
@@ -19,4 +19,13 @@ interface SeatJpaRepository : JpaRepository<SeatEntity, Long> {
       """)
     @QueryHints(QueryHint(name = "jakarta.persistence.lock.timeout", value = "3000"))
     fun findByTheaterIdAndSeatIdsByPessimisticLock(theaterId: Long, seatIds: List<Long>): List<SeatEntity>
+
+    @Lock(LockModeType.OPTIMISTIC)
+    @Query("""
+    SELECT s 
+    FROM seats s 
+    WHERE s.theater.id = :theaterId 
+      AND s.id IN :seatIds 
+      """)
+    fun findByTheaterIdAndSeatIdsByOptimisticLock(theaterId: Long, seatIds: List<Long>): List<SeatEntity>
 }

--- a/infrastructure/src/main/kotlin/com/hanghe/redis/mysql/seat/SeatJpaRepository.kt
+++ b/infrastructure/src/main/kotlin/com/hanghe/redis/mysql/seat/SeatJpaRepository.kt
@@ -1,31 +1,9 @@
 package com.hanghe.redis.mysql.seat
 
 import com.hanghe.redis.movie.seat.SeatEntity
-import jakarta.persistence.LockModeType
-import jakarta.persistence.QueryHint
 import org.springframework.data.jpa.repository.JpaRepository
-import org.springframework.data.jpa.repository.Lock
-import org.springframework.data.jpa.repository.Query
-import org.springframework.data.jpa.repository.QueryHints
 
 interface SeatJpaRepository : JpaRepository<SeatEntity, Long> {
 
-    @Lock(LockModeType.PESSIMISTIC_WRITE)
-    @Query("""
-    SELECT s 
-    FROM seats s 
-    WHERE s.theater.id = :theaterId 
-      AND s.id IN :seatIds 
-      """)
-    @QueryHints(QueryHint(name = "jakarta.persistence.lock.timeout", value = "3000"))
-    fun findByTheaterIdAndSeatIdsByPessimisticLock(theaterId: Long, seatIds: List<Long>): List<SeatEntity>
-
-    @Lock(LockModeType.OPTIMISTIC)
-    @Query("""
-    SELECT s 
-    FROM seats s 
-    WHERE s.theater.id = :theaterId 
-      AND s.id IN :seatIds 
-      """)
-    fun findByTheaterIdAndSeatIdsByOptimisticLock(theaterId: Long, seatIds: List<Long>): List<SeatEntity>
+    fun findByTheaterIdAndIdIn(theaterId: Long, seatIds: List<Long>): List<SeatEntity>
 }

--- a/infrastructure/src/main/kotlin/com/hanghe/redis/mysql/seat/SeatJpaRepository.kt
+++ b/infrastructure/src/main/kotlin/com/hanghe/redis/mysql/seat/SeatJpaRepository.kt
@@ -1,7 +1,22 @@
 package com.hanghe.redis.mysql.seat
 
 import com.hanghe.redis.movie.seat.SeatEntity
+import jakarta.persistence.LockModeType
+import jakarta.persistence.QueryHint
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Lock
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.jpa.repository.QueryHints
 
 interface SeatJpaRepository : JpaRepository<SeatEntity, Long> {
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("""
+    SELECT s 
+    FROM seats s 
+    WHERE s.theater.id = :theaterId 
+      AND s.id IN :seatIds 
+      """)
+    @QueryHints(QueryHint(name = "jakarta.persistence.lock.timeout", value = "3000"))
+    fun findByTheaterIdAndSeatIdsByPessimisticLock(theaterId: Long, seatIds: List<Long>): List<SeatEntity>
 }

--- a/infrastructure/src/main/kotlin/com/hanghe/redis/mysql/seat/SeatJpaRepository.kt
+++ b/infrastructure/src/main/kotlin/com/hanghe/redis/mysql/seat/SeatJpaRepository.kt
@@ -1,0 +1,7 @@
+package com.hanghe.redis.mysql.seat
+
+import com.hanghe.redis.movie.seat.SeatEntity
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface SeatJpaRepository : JpaRepository<SeatEntity, Long> {
+}

--- a/infrastructure/src/main/kotlin/com/hanghe/redis/mysql/seat/SeatRepository.kt
+++ b/infrastructure/src/main/kotlin/com/hanghe/redis/mysql/seat/SeatRepository.kt
@@ -8,7 +8,5 @@ interface SeatRepository {
 
     fun findByScreeningIdAndSeatIds(screeningId: Long, seatIds: List<Long>): List<SeatEntity>
 
-    fun findByTheaterIdAndSeatIdsByPessimisticLock(theaterId: Long, seatIds: List<Long>): List<SeatEntity>
-
-    fun findByTheaterIdAndSeatIdsByOptimisticLock(theaterId: Long, seatIds: List<Long>): List<SeatEntity>
+    fun findByTheaterIdAndSeatIds(theaterId: Long, seatIds: List<Long>): List<SeatEntity>
 }

--- a/infrastructure/src/main/kotlin/com/hanghe/redis/mysql/seat/SeatRepository.kt
+++ b/infrastructure/src/main/kotlin/com/hanghe/redis/mysql/seat/SeatRepository.kt
@@ -9,4 +9,6 @@ interface SeatRepository {
     fun findByScreeningIdAndSeatIds(screeningId: Long, seatIds: List<Long>): List<SeatEntity>
 
     fun findByTheaterIdAndSeatIdsByPessimisticLock(theaterId: Long, seatIds: List<Long>): List<SeatEntity>
+
+    fun findByTheaterIdAndSeatIdsByOptimisticLock(theaterId: Long, seatIds: List<Long>): List<SeatEntity>
 }

--- a/infrastructure/src/main/kotlin/com/hanghe/redis/mysql/seat/SeatRepository.kt
+++ b/infrastructure/src/main/kotlin/com/hanghe/redis/mysql/seat/SeatRepository.kt
@@ -1,0 +1,10 @@
+package com.hanghe.redis.mysql.seat
+
+import com.hanghe.redis.movie.seat.SeatEntity
+
+interface SeatRepository {
+
+    fun findByTheaterIdAndSeatIdsIn(theaterId: Any, seatIds: List<Long>): List<SeatEntity>
+
+    fun findByScreeningIdAndSeatIds(screeningId: Long, seatIds: List<Long>): List<SeatEntity>
+}

--- a/infrastructure/src/main/kotlin/com/hanghe/redis/mysql/seat/SeatRepository.kt
+++ b/infrastructure/src/main/kotlin/com/hanghe/redis/mysql/seat/SeatRepository.kt
@@ -4,7 +4,9 @@ import com.hanghe.redis.movie.seat.SeatEntity
 
 interface SeatRepository {
 
-    fun findByTheaterIdAndSeatIdsIn(theaterId: Any, seatIds: List<Long>): List<SeatEntity>
+    fun findByTheaterIdAndSeatIdsIn(theaterId: Long, seatIds: List<Long>): List<SeatEntity>
 
     fun findByScreeningIdAndSeatIds(screeningId: Long, seatIds: List<Long>): List<SeatEntity>
+
+    fun findByTheaterIdAndSeatIdsByPessimisticLock(theaterId: Long, seatIds: List<Long>): List<SeatEntity>
 }

--- a/infrastructure/src/main/kotlin/com/hanghe/redis/mysql/seat/SeatRepositoryImpl.kt
+++ b/infrastructure/src/main/kotlin/com/hanghe/redis/mysql/seat/SeatRepositoryImpl.kt
@@ -43,6 +43,10 @@ class SeatRepositoryImpl(
         return seatJpaRepository.findByTheaterIdAndSeatIdsByPessimisticLock(theaterId, seatIds)
     }
 
+    override fun findByTheaterIdAndSeatIdsByOptimisticLock(theaterId: Long, seatIds: List<Long>): List<SeatEntity> {
+        return seatJpaRepository.findByTheaterIdAndSeatIdsByOptimisticLock(theaterId, seatIds)
+    }
+
     companion object {
         private val qSeat = QSeatEntity.seatEntity
         private val qTheater = QTheaterEntity.theaterEntity

--- a/infrastructure/src/main/kotlin/com/hanghe/redis/mysql/seat/SeatRepositoryImpl.kt
+++ b/infrastructure/src/main/kotlin/com/hanghe/redis/mysql/seat/SeatRepositoryImpl.kt
@@ -39,12 +39,8 @@ class SeatRepositoryImpl(
             .fetch()
     }
 
-    override fun findByTheaterIdAndSeatIdsByPessimisticLock(theaterId: Long, seatIds: List<Long>): List<SeatEntity> {
-        return seatJpaRepository.findByTheaterIdAndSeatIdsByPessimisticLock(theaterId, seatIds)
-    }
-
-    override fun findByTheaterIdAndSeatIdsByOptimisticLock(theaterId: Long, seatIds: List<Long>): List<SeatEntity> {
-        return seatJpaRepository.findByTheaterIdAndSeatIdsByOptimisticLock(theaterId, seatIds)
+    override fun findByTheaterIdAndSeatIds(theaterId: Long, seatIds: List<Long>): List<SeatEntity> {
+        return seatJpaRepository.findByTheaterIdAndIdIn(theaterId, seatIds)
     }
 
     companion object {

--- a/infrastructure/src/main/kotlin/com/hanghe/redis/mysql/seat/SeatRepositoryImpl.kt
+++ b/infrastructure/src/main/kotlin/com/hanghe/redis/mysql/seat/SeatRepositoryImpl.kt
@@ -9,14 +9,15 @@ import org.springframework.stereotype.Repository
 
 @Repository
 class SeatRepositoryImpl(
+    private val seatJpaRepository: SeatJpaRepository,
     private val jpaQueryFactory: JPAQueryFactory
 ) : SeatRepository {
 
-    override fun findByTheaterIdAndSeatIdsIn(theaterId: Any, seatIds: List<Long>): List<SeatEntity> {
+    override fun findByTheaterIdAndSeatIdsIn(theaterId: Long, seatIds: List<Long>): List<SeatEntity> {
         return jpaQueryFactory
             .selectFrom(qSeat)
             .where(
-                qSeat.theater.id.eq(theaterId as Long),
+                qSeat.theater.id.eq(theaterId),
                 qSeat.id.`in`(seatIds)
             )
             .fetch()
@@ -36,6 +37,10 @@ class SeatRepositoryImpl(
                 qSeat.id.`in`(seatIds)
             )
             .fetch()
+    }
+
+    override fun findByTheaterIdAndSeatIdsByPessimisticLock(theaterId: Long, seatIds: List<Long>): List<SeatEntity> {
+        return seatJpaRepository.findByTheaterIdAndSeatIdsByPessimisticLock(theaterId, seatIds)
     }
 
     companion object {

--- a/infrastructure/src/main/kotlin/com/hanghe/redis/mysql/seat/SeatRepositoryImpl.kt
+++ b/infrastructure/src/main/kotlin/com/hanghe/redis/mysql/seat/SeatRepositoryImpl.kt
@@ -1,0 +1,46 @@
+package com.hanghe.redis.mysql.seat
+
+import com.hanghe.redis.movie.seat.QSeatEntity
+import com.hanghe.redis.movie.seat.SeatEntity
+import com.hanghe.redis.screening.QScreeningEntity
+import com.hanghe.redis.theater.QTheaterEntity
+import com.querydsl.jpa.impl.JPAQueryFactory
+import org.springframework.stereotype.Repository
+
+@Repository
+class SeatRepositoryImpl(
+    private val jpaQueryFactory: JPAQueryFactory
+) : SeatRepository {
+
+    override fun findByTheaterIdAndSeatIdsIn(theaterId: Any, seatIds: List<Long>): List<SeatEntity> {
+        return jpaQueryFactory
+            .selectFrom(qSeat)
+            .where(
+                qSeat.theater.id.eq(theaterId as Long),
+                qSeat.id.`in`(seatIds)
+            )
+            .fetch()
+    }
+
+    override fun findByScreeningIdAndSeatIds(
+        screeningId: Long,
+        seatIds: List<Long>
+    ): List<SeatEntity> {
+        return jpaQueryFactory
+            .select(qSeat)
+            .from(qSeat)
+            .join(qSeat.theater, qTheater)
+            .join(qScreening).on(qScreening.theater.id.eq(qTheater.id))
+            .where(
+                qScreening.id.eq(screeningId),
+                qSeat.id.`in`(seatIds)
+            )
+            .fetch()
+    }
+
+    companion object {
+        private val qSeat = QSeatEntity.seatEntity
+        private val qTheater = QTheaterEntity.theaterEntity
+        private val qScreening = QScreeningEntity.screeningEntity
+    }
+}

--- a/k6/concurreny.js
+++ b/k6/concurreny.js
@@ -3,7 +3,7 @@ import { sleep } from 'k6';
 
 export const options = {
     vus: 5,               // 동시에 요청할 가상 유저 수
-    duration: '5s',        // 테스트 시간 (원하면 조절 가능)
+    duration: '2s',        // 테스트 시간 (원하면 조절 가능)
 };
 
 export default function () {

--- a/k6/concurreny.js
+++ b/k6/concurreny.js
@@ -1,0 +1,27 @@
+import http from 'k6/http';
+import { sleep } from 'k6';
+
+export const options = {
+    vus: 5,               // 동시에 요청할 가상 유저 수
+    duration: '5s',        // 테스트 시간 (원하면 조절 가능)
+};
+
+export default function () {
+    const url = 'http://localhost:8080/api/v1/movies/reservations';
+
+    const payload = JSON.stringify({
+        screeningId: 1,
+        userId: `user-${__VU}`,      // 각 VU마다 유니크한 userId 부여
+        seatIds: [2]                 // 모두 동일한 좌석 ID 요청 (동시성 충돌 유도)
+    });
+
+    const params = {
+        headers: {
+            'Content-Type': 'application/json',
+        },
+    };
+
+    http.post(url, payload, params);
+
+    sleep(1);
+}

--- a/sql/ddl.sql
+++ b/sql/ddl.sql
@@ -56,7 +56,7 @@ CREATE INDEX idx_start_time ON screenings (start_time);
 CREATE TABLE seats
 (
     id         BIGINT UNSIGNED       NOT NULL AUTO_INCREMENT COMMENT '좌석 ID',
-    seat_code  VARCHAR(255) NOT NULL COMMENT '좌석 코드',
+    seat_code  VARCHAR(10) NOT NULL COMMENT '좌석 코드',
     theater_id BIGINT UNSIGNED       NOT NULL COMMENT '극장 ID',
     created_at TIMESTAMP DEFAULT NOW() COMMENT '생성 일시',
     created_by VARCHAR(255) COMMENT '생성자',
@@ -65,6 +65,8 @@ CREATE TABLE seats
     PRIMARY KEY (id),
     FOREIGN KEY (theater_id) REFERENCES theaters (id)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+CREATE INDEX idx_seats_theater_id ON seats (theater_id);
 
 
 -- 예약 테이블
@@ -81,3 +83,5 @@ CREATE TABLE reservations
     FOREIGN KEY (screening_id) REFERENCES screenings (id),
     FOREIGN KEY (seat_id) REFERENCES seats (id)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+UNIQUE KEY uniq_screening_seat (screening_id, seat_id)

--- a/sql/ddl.sql
+++ b/sql/ddl.sql
@@ -15,7 +15,7 @@ CREATE TABLE movies
     PRIMARY KEY (id)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
-CREATE INDEX idx_title_genre ON movies (title, genre);
+CREATE INDEX idx_genre_title ON movies (genre, title);
 
 
 -- 극장 테이블

--- a/sql/ddl.sql
+++ b/sql/ddl.sql
@@ -84,4 +84,4 @@ CREATE TABLE reservations
     FOREIGN KEY (seat_id) REFERENCES seats (id)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
-UNIQUE KEY uniq_screening_seat (screening_id, seat_id)
+CREATE INDEX idx_screening_seat ON reservations (screening_id, seat_id)


### PR DESCRIPTION
### [3주차] 예약 API 구현, Lock 적용 & 동시성 이슈 fix
  
  
### 📝작업 내용  
> 주말에 개인 일정으로 인해 Lock 검증/테스트 코드 & 분산락 적용 부분은 구현하지 못했습니다. 비즈니스 요구사항을 구현하는데 시간을 너무 많이 썼네요 😢 우선적으로 PR 요청 드리고, 나머지 작업 시간되는대로 구현해보겠습니다~

- 예약 API 구현
- 비관적 락 (Pessimistic Lock) 적용
- 낙관적 락 (Optimistic Lock) 적용
- (TODO) 분산락 적용
- (TODO) 함수형 분산락 적용

### 🔒해결하려는 문제 혹은 고민이 되었던 부분을 남겨주세요.(문제 수 만큼 복사해서 사용할 것)
-  비즈니스 요구사항 구현

### 🔑해당 문제를 어떻게 해결했나요? 그리고 왜 그렇게 생각했는지 이유를 남겨주세요.(자세하게 남겨주실 수록 좋습니다.)
-  비즈니스 요구사항을 꼼꼼히 구현하는데 많은 시간을 할애한 것 같아요. 꽤나 까다로운 요구사항들이 있어서 꼼꼼한 검증이 필요할 것 같아요.

### 🔒해결하려는 문제 혹은 고민이 되었던 부분을 남겨주세요.(문제 수 만큼 복사해서 사용할 것)
-  VO 클래스들 (SeatCode, SeatCodes)

### 🔑해당 문제를 어떻게 해결했나요? 그리고 왜 그렇게 생각했는지 이유를 남겨주세요.(자세하게 남겨주실 수록 좋습니다.)
-  최초 요구사항을 Service 레이어 내에 전부 구현하였으나, 서비스 레이어의 역할이 너무 많아지는 듯 하여 이와 관련해서는 클래스를 조금 분리해봤어요. 로직이나 구조가 어색하지는 않은지 확인 해주시면 감사하겠습니다 🙇 

### 🔒해결하려는 문제 혹은 고민이 되었던 부분을 남겨주세요.(문제 수 만큼 복사해서 사용할 것)
-  비관적락/낙관적락 적용

### 🔑해당 문제를 어떻게 해결했나요? 그리고 왜 그렇게 생각했는지 이유를 남겨주세요.(자세하게 남겨주실 수록 좋습니다.)
- ~~리소스가 부족하여 충분한 검증을 진행하지 못하였는데, 현재 로직대로라면 성능 이슈가 꽤나 발생할 것 같습니다. `MovieReservationService` 클래스의 예약 함수 내에서, Lock은 seats 조회하는 부분에서 잡고 있는데, 이후 예약 테이블에도 saveAll을 통한 데이터 추가 후 트랜잭션이 종료되어야 Lock이 풀리게 되어서 트랜잭션을 굉장히 길게 잡고 있을 것 같네요. saveAll도 JPA 함수라 굉장히 느릴텐데, Bulk Insert 방법이 아닌 다른 방법으로 개선 포인트가 있을까요? 🤔 (뭔가 현재 설계/Lock의 범위를 잘못 설정한 것 같기도 합니다...)~~

- Lock을 좌석이 아닌 예약으로 주체를 변경하였고, 이로 인해 비관/낙관락 적용 시 중복 예매 안되는 것까지 확인했습니다. 추가적으로 테스트 케이스 & 부하 테스트 등이 필요할 것 같네요.




### 💬리뷰 요구사항(선택)  
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요  
> ex) 메서드 ㅇㅇ의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
-  
-
-
-  
---
### 기타 사항 📌  
추가로 언급할 사항이 있다면 여기에 적어주세요.  

